### PR TITLE
fix: API HTTPS 프로토콜 강제 적용 및 언어 선택기 버그 수정

### DIFF
--- a/src/config/api.config.ts
+++ b/src/config/api.config.ts
@@ -1,38 +1,41 @@
 // API Configuration with automatic protocol detection
 
 const getApiUrl = () => {
-  const baseUrl = import.meta.env.VITE_API_URL;
+  const baseUrl = import.meta.env.VITE_API_URL || 'https://api.qalearningweb.com/api/v1';
   
-  // In production, ensure HTTPS is used
+  // Always use HTTPS in production when page is served over HTTPS
   if (typeof window !== 'undefined' && window.location.protocol === 'https:') {
-    // Force HTTPS for any configured URL when page is served over HTTPS
-    if (baseUrl) {
-      return baseUrl.replace(/^http:/, 'https:');
-    }
-    return 'https://api.qalearningweb.com/api/v1';
+    return baseUrl.replace(/^http:/, 'https:');
   }
   
-  return baseUrl || 'http://localhost:8000/api/v1';
+  // For local development
+  if (typeof window !== 'undefined' && window.location.hostname === 'localhost') {
+    return import.meta.env.VITE_API_URL || 'http://localhost:8000/api/v1';
+  }
+  
+  return baseUrl;
 };
 
 const getWsUrl = () => {
-  const wsUrl = import.meta.env.VITE_WS_URL;
+  const wsUrl = import.meta.env.VITE_WS_URL || 'wss://api.qalearningweb.com/ws';
   
-  // In production, ensure WSS is used
+  // Always use WSS in production when page is served over HTTPS
   if (typeof window !== 'undefined' && window.location.protocol === 'https:') {
-    // Force WSS for any configured URL when page is served over HTTPS
-    if (wsUrl) {
-      return wsUrl.replace(/^ws:/, 'wss:');
-    }
-    return 'wss://api.qalearningweb.com/ws';
+    return wsUrl.replace(/^ws:/, 'wss:');
   }
   
-  return wsUrl || 'ws://localhost:8000/ws';
+  // For local development
+  if (typeof window !== 'undefined' && window.location.hostname === 'localhost') {
+    return import.meta.env.VITE_WS_URL || 'ws://localhost:8000/ws';
+  }
+  
+  return wsUrl;
 };
 
+// Export as getter functions to ensure dynamic evaluation
 export const API_CONFIG = {
-  API_URL: getApiUrl(),
-  WS_URL: getWsUrl(),
+  get API_URL() { return getApiUrl(); },
+  get WS_URL() { return getWsUrl(); },
 };
 
 export default API_CONFIG;


### PR DESCRIPTION
  - API 설정을 동적 getter 함수로 변경하여 런타임 평가
  - 프로덕션 환경에서 항상 HTTPS/WSS 프로토콜 사용
  - 기본값을 HTTPS로 설정하여 Mixed Content 오류 방지
  - 언어 선택기 초기 상태 표시 오류 수정 (ko-KR 형식 지원)