### PR TITLE
fix: API 요청 시 동적 HTTPS URL 사용으로 Mixed Content 완전 해결

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,14 +1,12 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { API_CONFIG } from '../config/api.config';
 
-const API_BASE_URL = API_CONFIG.API_URL;
-
 class ApiService {
   private axiosInstance: AxiosInstance;
 
   constructor() {
     this.axiosInstance = axios.create({
-      baseURL: API_BASE_URL,
+      // baseURL will be set dynamically in interceptor
       timeout: 30000, // Increased to 30 seconds for email operations
       headers: {
         'Content-Type': 'application/json',
@@ -21,6 +19,14 @@ class ApiService {
     // Request interceptor
     this.axiosInstance.interceptors.request.use(
       (config) => {
+        // Dynamically set baseURL for each request
+        const apiUrl = API_CONFIG.API_URL;
+        
+        // If URL is relative, prepend the base URL
+        if (config.url && !config.url.startsWith('http')) {
+          config.url = apiUrl + (config.url.startsWith('/') ? config.url : '/' + config.url);
+        }
+        
         const token = localStorage.getItem('accessToken');
         if (token) {
           config.headers.Authorization = `Bearer ${token}`;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,13 +1,16 @@
 import { API_CONFIG } from '../config/api.config';
 
-// API Configuration
-export const API_BASE_URL = API_CONFIG.API_URL;
+// API Configuration - Use getters for dynamic evaluation
+export const getApiBaseUrl = () => API_CONFIG.API_URL;
+export const getWsBaseUrl = () => API_CONFIG.WS_URL;
+
+// For backwards compatibility (deprecated - will be removed)
+export const API_BASE_URL = getApiBaseUrl();
+export const WS_BASE_URL = getWsBaseUrl();
+
 export const API_TIMEOUT = 30000; // 30 seconds
 export const API_RETRY_ATTEMPTS = 3;
 export const API_RETRY_DELAY = 1000; // 1 second
-
-// WebSocket Configuration
-export const WS_BASE_URL = API_CONFIG.WS_URL;
 export const WS_RECONNECT_INTERVAL = 5000;
 export const WS_MAX_RECONNECT_ATTEMPTS = 5;
 export const WS_PING_INTERVAL = 30000;


### PR DESCRIPTION
  - axios interceptor에서 각 요청마다 동적으로 API URL 설정
  - 정적 변수 대신 getter 함수로 런타임 평가
  - 모든 API 호출에서 HTTPS 프로토콜 강제 적용