### PR TITLE
fix: 브라우저 레벨에서 모든 HTTP 요청을 HTTPS로 강제 변환

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -23,7 +23,7 @@
     <!-- LinkedIn specific -->
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <script type="module" crossorigin src="/assets/index-Db6G-Ln1.js"></script>
+    <script type="module" crossorigin src="/assets/index-yXkAeSS2.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/react-vendor-D3-UYpD9.js">
     <link rel="modulepreload" crossorigin href="/assets/state-CLZ3qR41.js">
     <link rel="modulepreload" crossorigin href="/assets/ui-libs-DjUinw3m.js">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,10 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './i18n/config'
 import './styles/globals.css'
+import { enforceHttpsInProduction } from './utils/forceHttps'
+
+// Force HTTPS for all API requests in production
+enforceHttpsInProduction();
 
 // Suppress React DevTools message in development
 if (import.meta.env.DEV) {

--- a/src/utils/forceHttps.ts
+++ b/src/utils/forceHttps.ts
@@ -1,0 +1,46 @@
+// Force HTTPS for all API requests in production
+export function enforceHttpsInProduction() {
+  if (typeof window === 'undefined') return;
+  
+  const isProduction = window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1';
+  
+  if (!isProduction) return;
+  
+  console.warn('Enforcing HTTPS for all API requests');
+  
+  // Override XMLHttpRequest
+  const originalXHROpen = XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open = function(method: string, url: string | URL, ...args: any[]) {
+    let modifiedUrl = url.toString();
+    
+    // Force HTTPS for api.qalearningweb.com
+    if (modifiedUrl.includes('api.qalearningweb.com') && modifiedUrl.startsWith('http://')) {
+      modifiedUrl = modifiedUrl.replace('http://', 'https://');
+      console.warn('Forced HTTPS for XMLHttpRequest:', modifiedUrl);
+    }
+    
+    return originalXHROpen.apply(this, [method, modifiedUrl, ...args] as any);
+  };
+  
+  // Override fetch
+  const originalFetch = window.fetch;
+  window.fetch = function(input: RequestInfo | URL, init?: RequestInit) {
+    let url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    
+    // Force HTTPS for api.qalearningweb.com
+    if (url.includes('api.qalearningweb.com') && url.startsWith('http://')) {
+      const httpsUrl = url.replace('http://', 'https://');
+      console.warn('Forced HTTPS for fetch:', httpsUrl);
+      
+      if (typeof input === 'string') {
+        input = httpsUrl;
+      } else if (input instanceof URL) {
+        input = new URL(httpsUrl);
+      } else {
+        input = new Request(httpsUrl, input);
+      }
+    }
+    
+    return originalFetch.call(window, input, init);
+  };
+}


### PR DESCRIPTION
  - XMLHttpRequest와 fetch API 오버라이드
  - api.qalearningweb.com으로의 모든 HTTP 요청을 HTTPS로 변경
  - 프로덕션 환경에서만 적용