### PR TITLE
프로덕션 로그인 문제 및 칸반 보드 열 순서 수정

### DIFF
--- a/src/pages/KanbanPage.tsx
+++ b/src/pages/KanbanPage.tsx
@@ -304,31 +304,38 @@ const KanbanPage: React.FC = () => {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
           {displayBoard?.columns && displayBoard.columns.length > 0 ? (
-            displayBoard.columns.map(column => {
-            const columnTasks = column.cards || [];
-            
-            // Map English column titles to translation keys
-            const titleToKey = {
-              'todo': 'todo',
-              'To Do': 'todo',
-              'inProgress': 'inProgress',
-              'In Progress': 'inProgress',
-              'review': 'review',
-              'Review': 'review',
-              'done': 'done',
-              'Done': 'done',
-              // Also check for already translated titles
-              [t('kanban.columns.todo')]: 'todo',
-              [t('kanban.columns.inProgress')]: 'inProgress',
-              [t('kanban.columns.review')]: 'review',
-              [t('kanban.columns.done')]: 'done'
-            };
-            
-            const columnKey = titleToKey[column.title] || 'todo';
-            const displayTitle = t(`kanban.columns.${columnKey}`);
-            const columnConfig = columns.find(c => c.id === columnKey) || columns[0];
-            
-            return (
+            // Sort columns according to the predefined order
+            columns.map(columnConfig => {
+              // Map English column titles to translation keys
+              const titleToKey = {
+                'todo': 'todo',
+                'To Do': 'todo',
+                'inProgress': 'inProgress',
+                'In Progress': 'inProgress',
+                'review': 'review',
+                'Review': 'review',
+                'done': 'done',
+                'Done': 'done',
+                // Also check for already translated titles
+                [t('kanban.columns.todo')]: 'todo',
+                [t('kanban.columns.inProgress')]: 'inProgress',
+                [t('kanban.columns.review')]: 'review',
+                [t('kanban.columns.done')]: 'done'
+              };
+              
+              // Find the matching column from displayBoard
+              const column = displayBoard.columns.find(col => {
+                const key = titleToKey[col.title];
+                return key === columnConfig.id;
+              });
+              
+              if (!column) return null;
+              
+              const columnTasks = column.cards || [];
+              const columnKey = columnConfig.id;
+              const displayTitle = columnConfig.title;
+              
+              return (
               <div key={column.id} className="flex flex-col">
                 <div className="mb-4">
                   <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
@@ -434,7 +441,7 @@ const KanbanPage: React.FC = () => {
                 </div>
               </div>
             );
-          })
+          }).filter(Boolean)
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
               {columns.map(col => (

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -26,15 +26,30 @@ const SignupPage: React.FC = () => {
       await register(data);
       navigate('/dashboard');
     } catch (err: any) {
-      let errorMessage = err.response?.data?.detail || err.message || t('auth.signup.errors.signupFailed');
+      let errorMessage = '';
+      
+      // Handle 422 validation errors (FastAPI format)
+      if (err.response?.status === 422 && err.response?.data?.detail) {
+        const detail = err.response.data.detail;
+        if (Array.isArray(detail)) {
+          // Extract error messages from validation errors
+          errorMessage = detail.map((e: any) => e.msg || e.message || 'Validation error').join(', ');
+        } else {
+          errorMessage = detail;
+        }
+      } else {
+        errorMessage = err.response?.data?.detail || err.message || t('auth.signup.errors.signupFailed');
+      }
       
       // Translate specific error messages
-      if (errorMessage === 'This email was previously used and cannot be reused') {
-        errorMessage = t('auth.signup.errors.emailPreviouslyUsed');
-      } else if (errorMessage === 'This username was previously used and cannot be reused') {
-        errorMessage = t('auth.signup.errors.usernamePreviouslyUsed');
-      } else if (err.response?.status === 409) {
-        errorMessage = t('auth.signup.errors.emailAlreadyExists');
+      if (typeof errorMessage === 'string') {
+        if (errorMessage === 'This email was previously used and cannot be reused') {
+          errorMessage = t('auth.signup.errors.emailPreviouslyUsed');
+        } else if (errorMessage === 'This username was previously used and cannot be reused') {
+          errorMessage = t('auth.signup.errors.usernamePreviouslyUsed');
+        } else if (err.response?.status === 409) {
+          errorMessage = t('auth.signup.errors.emailAlreadyExists');
+        }
       }
       
       setError(errorMessage);


### PR DESCRIPTION
  - 누락된 사용자 테이블 컬럼 추가 마이그레이션 적용 (terms_accepted, privacy_accepted, terms_accepted_at)
  - FastAPI 422 검증 에러에 대한 프론트엔드 에러 처리 개선
  - 칸반 보드 열 표시 순서 수정: 할 일 → 진행 중 → 검토 → 완료
  - 데이터베이스 순서가 아닌 사전 정의된 순서로 열 렌더링하도록 수정